### PR TITLE
Fix compile error "No font" for example

### DIFF
--- a/examples/examples.gui
+++ b/examples/examples.gui
@@ -1,7 +1,7 @@
 script: "/examples/examples.gui_script"
 fonts {
   name: "system_font"
-  font: "/builtins/fonts/system_font.font"
+  font: "/builtins/fonts/debug/always_on_top.font"
 }
 background_color {
   x: 0.0


### PR DESCRIPTION
Current behaviour:
```
/examples/examples.gui
	The file '/builtins/fonts/system_font.font' could not be found.
```